### PR TITLE
feat: OpenCraft Header.

### DIFF
--- a/src/plugin-slots/CourseInfoSlot/index.jsx
+++ b/src/plugin-slots/CourseInfoSlot/index.jsx
@@ -18,6 +18,7 @@ const CourseInfoSlot = ({
       courseOrg,
       courseNumber,
       courseTitle,
+      attributes,
     }}
   >
     <LearningHeaderCourseInfo

--- a/src/plugin-slots/DesktopHeaderSlot/index.jsx
+++ b/src/plugin-slots/DesktopHeaderSlot/index.jsx
@@ -11,6 +11,7 @@ const DesktopHeaderSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={props}
   >
     <DesktopHeader {...props} />
   </PluginSlot>

--- a/src/plugin-slots/DesktopLoggedOutItemsSlot/index.jsx
+++ b/src/plugin-slots/DesktopLoggedOutItemsSlot/index.jsx
@@ -11,6 +11,7 @@ const DesktopLoggedOutItemsSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginPrope={{ items }}
   >
     <DesktopLoggedOutItems items={items} />
   </PluginSlot>

--- a/src/plugin-slots/DesktopMainMenuSlot/index.jsx
+++ b/src/plugin-slots/DesktopMainMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const DesktopMainMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ menu }}
   >
     <DesktopHeaderMainOrSecondaryMenu menu={menu} />
   </PluginSlot>

--- a/src/plugin-slots/DesktopSecondaryMenuSlot/index.jsx
+++ b/src/plugin-slots/DesktopSecondaryMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const DesktopSecondaryMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ menu }}
   >
     <DesktopHeaderMainOrSecondaryMenu menu={menu} />
   </PluginSlot>

--- a/src/plugin-slots/DesktopUserMenuSlot/index.jsx
+++ b/src/plugin-slots/DesktopUserMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const DesktopUserMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ menu }}
   >
     <DesktopHeaderUserMenu menu={menu} />
   </PluginSlot>

--- a/src/plugin-slots/LearningLoggedOutItemsSlot/index.jsx
+++ b/src/plugin-slots/LearningLoggedOutItemsSlot/index.jsx
@@ -11,6 +11,7 @@ const LearningLoggedOutItemsSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ buttonsInfo }}
   >
     <LearningLoggedOutButtons buttonsInfo={buttonsInfo} />
   </PluginSlot>

--- a/src/plugin-slots/LearningUserMenuSlot/index.jsx
+++ b/src/plugin-slots/LearningUserMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const LearningUserMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ items }}
   >
     <LearningHeaderUserMenuItems items={items} />
   </PluginSlot>

--- a/src/plugin-slots/LogoSlot/index.jsx
+++ b/src/plugin-slots/LogoSlot/index.jsx
@@ -11,6 +11,9 @@ const LogoSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    props={{
+      href, src, alt, attributes,
+    }}
   >
     <Logo href={href} src={src} alt={alt} {...attributes} />
   </PluginSlot>

--- a/src/plugin-slots/MobileHeaderSlot/index.jsx
+++ b/src/plugin-slots/MobileHeaderSlot/index.jsx
@@ -11,6 +11,7 @@ const MobileHeaderSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={props}
   >
     <MobileHeader {...props} />
   </PluginSlot>

--- a/src/plugin-slots/MobileLoggedOutItemsSlot/index.jsx
+++ b/src/plugin-slots/MobileLoggedOutItemsSlot/index.jsx
@@ -11,6 +11,7 @@ const MobileLoggedOutItemsSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ items }}
   >
     <MobileLoggedOutItems items={items} />
   </PluginSlot>

--- a/src/plugin-slots/MobileMainMenuSlot/index.jsx
+++ b/src/plugin-slots/MobileMainMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const MobileMainMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ menu }}
   >
     <MobileHeaderMainMenu menu={menu} />
   </PluginSlot>

--- a/src/plugin-slots/MobileUserMenuSlot/index.jsx
+++ b/src/plugin-slots/MobileUserMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const MobileUserMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ menu }}
   >
     <MobileHeaderUserMenu menu={menu} />
   </PluginSlot>


### PR DESCRIPTION
This MR prototypes our header design for sandboxes.

**JIRA ticket**: https://tasks.opencraft.com/browse/STAR-4174

**Figma Design**: https://www.figma.com/design/c5SgVI3M8VmkeMajJu3EFK/OpenCraft-Sandbox-Designs?node-id=0-1&p=f&t=WfH1TjTB0XE4f8lw-0

**Screenshots**: 

![image](https://github.com/user-attachments/assets/5de28094-9145-4c80-98f8-a501fb9837b2)

![image](https://github.com/user-attachments/assets/344b6d68-b690-4ad4-89e3-7b1a25d02023)

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.

**Testing instructions**:

1. Use `npm ci` to install the requirements
2. Add http://local.openedx.io:8080 to the CORS whitelist of your tutor installation using a plugin. You can also just whitelist everything since you're using a local dev instance:
    ```
   hooks.Filters.ENV_PATCHES.add_item(
      (
          "openedx-lms-common-settings",
          "CORS_ORIGIN_ALLOW_ALL = True",
      )
    )
    ```
3. Clone the [branding repo](https://github.com/open-craft/brand-openedx) into the public directory.
4. In the branding repo, check out the `fox/sandbox` branch.
5. `npm run start` to run the local server
6. Visit http://local.openedx.io:8080 and wait for it to load and see the different header variations.

**Author notes and concerns**:

This PR is not intended to actually be merged. It's here to show how I've prototyped the plugins locally. I've not yet dug into the best method of distributing these changes, but I do have them working locally this way, so taking the time to have them reviewed now before doing anything else.

The mobile header also doesn't quite match the design, since implementing it looked to be more complex than we had remaining time for.

Additionally, the avatar icon is upstream's icon, since I was not sure where it would be best to place/host a replacement icon file, and it was decently similar.